### PR TITLE
upgrade dependencies

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,11 +1,12 @@
-(defproject com.fzakaria/slf4j-timbre "0.2.2"
+(defproject com.fzakaria/slf4j-timbre "0.2.3"
   :description "SLF4J binding for Timbre"
   :url "https://github.com/fzakaria/slf4j-timbre"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.7.0"]
-                 [com.taoensso/timbre "4.1.4"]
-                 [org.slf4j/slf4j-api "1.7.12"]]
+                 [com.taoensso/timbre "4.2.0"]
+                 [org.slf4j/slf4j-api "1.7.13"]
+                 [org.clojure/tools.reader "1.0.0-alpha2"]]
 
   :plugins [[lein-ancient "0.6.5"]]
 


### PR DESCRIPTION
Upgrading Timbre dependency & SLF4J
Added tools.reader since its no longer part of Timbre.
