### PR TITLE
Initial Timbre integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,6 @@ Add `slf4j-timbre` to your project dependencies:
 
 [![Clojars Project](http://clojars.org/com.fzakaria/slf4j-timbre/latest-version.svg)](http://clojars.org/com.fzakaria/slf4j-timbre)
 
-**`slf4j-timbre` requires `[org.slf4j/slf4j-api "1.7.14"]` or later so make sure your project or its dependencies are not pulling in an earlier version.**
-
 You'll also want to make sure all other logging APIs are wrapped by SLF4J by including the following:
 
 ```clojure
@@ -19,6 +17,10 @@ You'll also want to make sure all other logging APIs are wrapped by SLF4J by inc
 [org.slf4j/jul-to-slf4j "1.7.14"]
 [org.slf4j/jcl-over-slf4j "1.7.14"]
 ```
+
+**`slf4j-timbre` requires `[org.slf4j/slf4j-api "1.7.14"]` or later so make sure your project or its dependencies are not pulling in an earlier version.**
+
+The project also makes use of features introduced in `[com.taoensso/timbre "4.3.0-RC1"]` so make sure this dependency isn't being shadowed by an earlier version of Timbre in your project.
 
 ## License
 

--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.7.0"]
-                 [com.taoensso/timbre "4.2.1"]
+                 [com.taoensso/timbre "4.3.0-SNAPSHOT"]
                  [org.slf4j/slf4j-api "1.7.14"]]
 
   :plugins [[lein-ancient "0.6.5"]]

--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,7 @@
 		 :url "http://www.eclipse.org/legal/epl-v10.html"}
 	:dependencies
 		[[org.clojure/clojure "1.7.0"]
-		 [com.taoensso/timbre "4.3.0-RC1"]
+		 [com.taoensso/timbre "4.3.1"]
 		 [org.slf4j/slf4j-api "1.7.14"]]
 	:profiles
 		{:dev

--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,6 @@
 		[[org.clojure/clojure "1.7.0"]
 		 [com.taoensso/timbre "4.3.0-SNAPSHOT"]
 		 [org.slf4j/slf4j-api "1.7.14"]]
-	:plugins [[lein-ancient "0.6.5"]]
 	:profiles
 		{:dev
 			{:dependencies [[midje "1.8.3"]]

--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,7 @@
 		 :url "http://www.eclipse.org/legal/epl-v10.html"}
 	:dependencies
 		[[org.clojure/clojure "1.7.0"]
-		 [com.taoensso/timbre "4.3.0-SNAPSHOT"]
+		 [com.taoensso/timbre "4.3.0-RC1"]
 		 [org.slf4j/slf4j-api "1.7.14"]]
 	:profiles
 		{:dev

--- a/project.clj
+++ b/project.clj
@@ -1,20 +1,19 @@
 (defproject com.fzakaria/slf4j-timbre "0.3.0"
-  :description "SLF4J binding for Timbre"
-  :url "https://github.com/fzakaria/slf4j-timbre"
-  :license {:name "Eclipse Public License"
-            :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.7.0"]
-                 [com.taoensso/timbre "4.3.0-SNAPSHOT"]
-                 [org.slf4j/slf4j-api "1.7.14"]]
-
-  :plugins [[lein-ancient "0.6.5"]]
-
-  :profiles {:dev {:dependencies [[midje "1.8.3"]]
-                   :plugins [[lein-midje "3.2"]]}}
-
-  :aot :all
-
-  :scm {:name "git"
-        :url "https://github.com/fzakaria/slf4j-timbre"}
-
-  )
+	:description "SLF4J binding for Timbre"
+	:url "https://github.com/fzakaria/slf4j-timbre"
+	:license
+		{:name "Eclipse Public License"
+		 :url "http://www.eclipse.org/legal/epl-v10.html"}
+	:dependencies
+		[[org.clojure/clojure "1.7.0"]
+		 [com.taoensso/timbre "4.3.0-SNAPSHOT"]
+		 [org.slf4j/slf4j-api "1.7.14"]]
+	:plugins [[lein-ancient "0.6.5"]]
+	:profiles
+		{:dev
+			{:dependencies [[midje "1.8.3"]]
+			 :plugins [[lein-midje "3.2"]]}}
+	:aot :all
+	:scm
+		{:name "git"
+		 :url "https://github.com/fzakaria/slf4j-timbre"})

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.fzakaria/slf4j-timbre "0.3.0"
+(defproject com.fzakaria/slf4j-timbre "0.3.1"
 	:description "SLF4J binding for Timbre"
 	:url "https://github.com/fzakaria/slf4j-timbre"
 	:license

--- a/src/slf4j_timbre/adapter.clj
+++ b/src/slf4j_timbre/adapter.clj
@@ -19,7 +19,7 @@
 	(.state this))
 
 (defmacro ^:private wrap
-	[level checker]
+	[level]
 	`(fn [this# & args#]
 		(letfn [(inner#
 				([msg#]
@@ -43,10 +43,16 @@
 									(timbre/log-call ~level :p [(.getMessage ft#)])))
 						(isa? (class o#) Throwable)
 							(timbre/log-call ~level :p [o# msg#]))))]
-			(when (~checker this#)
+			(when (timbre/log? ~level)
 				(if (isa? (class (first args#)) Marker)
 					(timbre/with-context {:marker (.getName (first args#))} (apply inner# (rest args#)))
 					(apply inner# args#))))))
+
+(def -error (wrap :error))
+(def -warn  (wrap :warn))
+(def -info  (wrap :info))
+(def -debug (wrap :debug))
+(def -trace (wrap :trace))
 
 (defn -isErrorEnabled
 	([_]   (timbre/log? :error))
@@ -63,9 +69,3 @@
 (defn -isTraceEnabled
 	([_]   (timbre/log? :trace))
 	([_ _] (timbre/log? :trace)))
-
-(def -error (wrap :error -isErrorEnabled))
-(def -warn  (wrap :warn  -isWarnEnabled))
-(def -info  (wrap :info  -isInfoEnabled))
-(def -debug (wrap :debug -isDebugEnabled))
-(def -trace (wrap :trace -isTraceEnabled))

--- a/src/slf4j_timbre/adapter.clj
+++ b/src/slf4j_timbre/adapter.clj
@@ -19,30 +19,30 @@
 	(.state this))
 
 (defmacro ^:private wrap
-	[method checker]
+	[level checker]
 	`(fn [this# & args#]
 		(letfn [(inner#
 				([msg#]
-					(~method msg#))
+					(timbre/log-call ~level :p [msg#]))
 				([msg# o1# o2#]
 					(let [ft# (MessageFormatter/format msg# o1# o2#)]
 						(if-let [t# (.getThrowable ft#)]
-							(~method t# (.getMessage ft#))
-							(~method (.getMessage ft#)))))
+							(timbre/log-call ~level :p [t# (.getMessage ft#)])
+							(timbre/log-call ~level :p [(.getMessage ft#)]))))
 				([msg# o#]
 					(cond
 						(string? o#)
 							(let [ft# (MessageFormatter/format msg# o#)]
 								(if-let [t# (.getThrowable ft#)]
-									(~method t# (.getMessage ft#))
-									(~method (.getMessage ft#))))
+									(timbre/log-call ~level :p [t# (.getMessage ft#)])
+									(timbre/log-call ~level :p [(.getMessage ft#)])))
 						(.isArray (class o#))
 							(let [ft# (MessageFormatter/arrayFormat msg# o#)]
 								(if-let [t# (.getThrowable ft#)]
-									(~method t# (.getMessage ft#))
-									(~method (.getMessage ft#))))
+									(timbre/log-call ~level :p [t# (.getMessage ft#)])
+									(timbre/log-call ~level :p [(.getMessage ft#)])))
 						(isa? (class o#) Throwable)
-							(~method o# msg#))))]
+							(timbre/log-call ~level :p [o# msg#]))))]
 			(when (~checker this#)
 				(if (isa? (class (first args#)) Marker)
 					(timbre/with-context {:marker (.getName (first args#))} (apply inner# (rest args#)))
@@ -64,8 +64,8 @@
 	([_]   (timbre/log? :trace))
 	([_ _] (timbre/log? :trace)))
 
-(def -error (wrap timbre/error -isErrorEnabled))
-(def -warn  (wrap timbre/warn  -isWarnEnabled))
-(def -info  (wrap timbre/info  -isInfoEnabled))
-(def -debug (wrap timbre/debug -isDebugEnabled))
-(def -trace (wrap timbre/trace -isTraceEnabled))
+(def -error (wrap :error -isErrorEnabled))
+(def -warn  (wrap :warn  -isWarnEnabled))
+(def -info  (wrap :info  -isInfoEnabled))
+(def -debug (wrap :debug -isDebugEnabled))
+(def -trace (wrap :trace -isTraceEnabled))

--- a/src/slf4j_timbre/adapter.clj
+++ b/src/slf4j_timbre/adapter.clj
@@ -38,7 +38,7 @@
 						(isa? (class o#) Throwable)
 							(~method o# msg#))))]
 			(if (isa? (class (first args#)) Marker)
-				(apply inner# (rest args#))
+				(timbre/with-context {:marker (.getName (first args#))} (apply inner# (rest args#)))
 				(apply inner# args#)))))
 
 (def -error (wrap timbre/error))

--- a/src/slf4j_timbre/adapter.clj
+++ b/src/slf4j_timbre/adapter.clj
@@ -23,26 +23,26 @@
 	[level {:keys [?ns-str ?file ?line]}]
 	(fn
 		([msg]
-			(timbre/log-call level :p [msg] {:?ns-str ?ns-str :?file ?file :?line ?line}))
+			(timbre/log! level :p [msg] {:?ns-str ?ns-str :?file ?file :?line ?line}))
 		([msg o1 o2]
 			(let [ft (MessageFormatter/format msg o1 o2)]
 				(if-let [t (.getThrowable ft)]
-					(timbre/log-call level :p [t (.getMessage ft)] {:?ns-str ?ns-str :?file ?file :?line ?line})
-					(timbre/log-call level :p [  (.getMessage ft)] {:?ns-str ?ns-str :?file ?file :?line ?line}))))
+					(timbre/log! level :p [t (.getMessage ft)] {:?ns-str ?ns-str :?file ?file :?line ?line})
+					(timbre/log! level :p [  (.getMessage ft)] {:?ns-str ?ns-str :?file ?file :?line ?line}))))
 		([msg o]
 			(cond
 				(string? o)
 					(let [ft (MessageFormatter/format msg o)]
 						(if-let [t (.getThrowable ft)]
-							(timbre/log-call level :p [t (.getMessage ft)] {:?ns-str ?ns-str :?file ?file :?line ?line})
-							(timbre/log-call level :p [  (.getMessage ft)] {:?ns-str ?ns-str :?file ?file :?line ?line})))
+							(timbre/log! level :p [t (.getMessage ft)] {:?ns-str ?ns-str :?file ?file :?line ?line})
+							(timbre/log! level :p [  (.getMessage ft)] {:?ns-str ?ns-str :?file ?file :?line ?line})))
 				(.isArray (class o))
 					(let [ft (MessageFormatter/arrayFormat msg o)]
 						(if-let [t (.getThrowable ft)]
-							(timbre/log-call level :p [t (.getMessage ft)] {:?ns-str ?ns-str :?file ?file :?line ?line})
-							(timbre/log-call level :p [  (.getMessage ft)] {:?ns-str ?ns-str :?file ?file :?line ?line})))
+							(timbre/log! level :p [t (.getMessage ft)] {:?ns-str ?ns-str :?file ?file :?line ?line})
+							(timbre/log! level :p [  (.getMessage ft)] {:?ns-str ?ns-str :?file ?file :?line ?line})))
 				(isa? (class o) Throwable)
-					(timbre/log-call level :p [o msg] {:?ns-str ?ns-str :?file ?file :?line ?line})))))
+					(timbre/log! level :p [o msg] {:?ns-str ?ns-str :?file ?file :?line ?line})))))
 
 (defmacro ^:private wrap
 	[level]

--- a/src/slf4j_timbre/adapter.clj
+++ b/src/slf4j_timbre/adapter.clj
@@ -5,7 +5,8 @@
 		:state        state
 		:init         init
 		:constructors {[String] []})
-	(:require [taoensso.timbre :as timbre])
+	(:require
+		[taoensso.timbre :as timbre])
 	(:import
 		[org.slf4j.helpers FormattingTuple MessageFormatter]
 		org.slf4j.Marker))
@@ -18,7 +19,7 @@
 	[this]
 	(.state this))
 
-(defn make-inner
+(defn make-log-fn
 	[level {:keys [?ns-str ?file ?line]}]
 	(fn
 		([msg]
@@ -54,10 +55,11 @@
 					{:?ns-str (.getName this#)
 					 :?file   (.getFileName caller#)
 					 :?line   (.getLineNumber caller#)}
-				 inner# (make-inner ~level opts#)]
+				 log# (make-log-fn ~level opts#)]
 				(if (isa? (class (first args#)) Marker)
-					(timbre/with-context {:marker (.getName (first args#))} (apply inner# (rest args#)))
-					(apply inner# args#))))))
+					(timbre/with-context {:marker (.getName (first args#))}
+						(apply log# (rest args#)))
+					(apply log# args#))))))
 
 (def -error (wrap :error))
 (def -warn  (wrap :warn))

--- a/src/slf4j_timbre/adapter.clj
+++ b/src/slf4j_timbre/adapter.clj
@@ -26,15 +26,21 @@
 					(~method msg#))
 				([msg# o1# o2#]
 					(let [ft# (MessageFormatter/format msg# o1# o2#)]
-						(~method (.getThrowable ft#) (.getMessage ft#))))
+						(if-let [t# (.getThrowable ft#)]
+							(~method t# (.getMessage ft#))
+							(~method (.getMessage ft#)))))
 				([msg# o#]
 					(cond
 						(string? o#)
 							(let [ft# (MessageFormatter/format msg# o#)]
-								(~method (.getThrowable ft#) (.getMessage ft#)))
+								(if-let [t# (.getThrowable ft#)]
+									(~method t# (.getMessage ft#))
+									(~method (.getMessage ft#))))
 						(.isArray (class o#))
 							(let [ft# (MessageFormatter/arrayFormat msg# o#)]
-								(~method (.getThrowable ft#) (.getMessage ft#)))
+								(if-let [t# (.getThrowable ft#)]
+									(~method t# (.getMessage ft#))
+									(~method (.getMessage ft#))))
 						(isa? (class o#) Throwable)
 							(~method o# msg#))))]
 			(when (~checker this#)


### PR DESCRIPTION
- populate Timbre `:?ns-str` with slf4j logger name (the FQN of the log site by convention)
- populate Timbre `?:file` and `?:line` from call stack
- put slf4j Marker name, if present, into Timbre `:context` map with key `:marker`

closes #12
