### PR TITLE
Only call .getFileName and .getLineNumber when the caller is not nil.

### DIFF
--- a/src/slf4j_timbre/adapter.clj
+++ b/src/slf4j_timbre/adapter.clj
@@ -111,15 +111,15 @@
 				(timbre/with-context (when marker# {:marker (.getName marker#)})
 					(if t#
 						(timbre/log! ~level-keyword :p
-							[t# message#]
-							{:?ns-str (.getName this#)
-							 :?file   (.getFileName caller#)
-							 :?line   (.getLineNumber caller#)})
+												 [t# message#]
+												 (cond-> {:?ns-str (.getName this#)}
+																 caller# (assoc :?file (.getFileName caller#)
+																								:?line (.getLineNumber caller#))))
 						(timbre/log! ~level-keyword :p
-							[message#]
-							{:?ns-str (.getName this#)
-							 :?file   (.getFileName caller#)
-							 :?line   (.getLineNumber caller#)})))))))
+												 [message#]
+												 (cond-> {:?ns-str (.getName this#)}
+																 caller# (assoc :?file (.getFileName caller#)
+																								:?line (.getLineNumber caller#))))))))))
 
 (define-log-method LocationAwareLogger/ERROR_INT :error)
 (define-log-method LocationAwareLogger/WARN_INT  :warn)


### PR DESCRIPTION
When working with Spymemcached I run into a NPE caused by the caller ([here](https://github.com/fzakaria/slf4j-timbre/blob/877a709a29a33b8c01d03f3b66001b994f81e95f/src/slf4j_timbre/adapter.clj#L109)) bein `nil`. 

This PR fixes the issue by only including `?:file` and `?line` in the `log!` call when the caller is not `nil`.