### PR TITLE
Add type hints to remove reflection when resolving java method calls

### DIFF
--- a/src/slf4j_timbre/factory.clj
+++ b/src/slf4j_timbre/factory.clj
@@ -5,14 +5,16 @@
 		:state state
 		:init init)
 	(:require slf4j-timbre.adapter)
-	(:import com.github.fzakaria.slf4j.timbre.TimbreLoggerAdapter))
+	(:import
+		com.github.fzakaria.slf4j.timbre.TimbreLoggerFactory
+		com.github.fzakaria.slf4j.timbre.TimbreLoggerAdapter))
 
 (defn -init
 	[]
 	[[] (atom {})])
 
 (defn -getLogger
-	[this logger-name]
+	[^TimbreLoggerFactory this logger-name]
 	(let [loggers (.state this) loggers-map @loggers]
 		(if-let [existing (get loggers-map logger-name)]
 			existing


### PR DESCRIPTION
Remove reflection via type hints.

Removing reflection makes slf4j-timbre more usable in [graalvm native images](https://github.com/oracle/graal/blob/master/substratevm/REFLECTION.md) where additional configuration is required when reflection is used.