### PR TITLE
fix race condition in factory that allowed to return null

### DIFF
--- a/src/slf4j_timbre/factory.clj
+++ b/src/slf4j_timbre/factory.clj
@@ -14,10 +14,10 @@
 
 (defn -getLogger
 	[^TimbreLoggerFactory this logger-name]
-	(let [loggers (.state this) loggers-map @loggers]
-		(if-let [existing (get loggers-map logger-name)]
-			existing
-			(let [new-logger (TimbreLoggerAdapter. logger-name)]
-				(if (compare-and-set! loggers loggers-map (assoc loggers-map logger-name new-logger))
-					new-logger
-					(get @loggers logger-name))))))
+	(or (let [loggers (.state this) loggers-map @loggers]
+        (if-let [existing (get loggers-map logger-name)]
+          existing
+          (let [new-logger (TimbreLoggerAdapter. logger-name)]
+            (get (swap! loggers update logger-name #(or % new-logger))
+                 logger-name))))
+      (throw (ex-info (str "Failed to get a logger for " logger-name) {:this this}))))


### PR DESCRIPTION
the compare-and-set! call doesn't guarantee it is our logger that has been
changed in the state map. If we don't want to change the logger in the state map
we should call swap! with update and use the result.

As a safe-guard I've put a throw in. Returning null from getLogger caused me to
debug for 4 hours where the issue lies. This will help others to pinpoint us in
case the code messes up again :)