### PR TITLE
Bugfix: `clojure.core/unquote` was still being used in the else block.

### DIFF
--- a/src/slf4j_timbre/adapter.clj
+++ b/src/slf4j_timbre/adapter.clj
@@ -142,8 +142,8 @@
                              :?file   (.getFileName caller)
                              :?line   (.getLineNumber caller)}))
              (if t
-               (timbre/log! ~level-keyword :p [t message] {:?ns-str (.getName this)})
-               (timbre/log! ~level-keyword :p   [message] {:?ns-str (.getName this)})))))))))
+               (timbre/log! level-keyword :p [t message] {:?ns-str (.getName this)})
+               (timbre/log! level-keyword :p   [message] {:?ns-str (.getName this)})))))))))
 
 
 (defn -isErrorEnabled


### PR DESCRIPTION
First of all thanks a lot for creating this lib :+1: 

I guess `-log` was a macro before, however in the else block two `~` were still being used.