### PR TITLE
Adapt init to work with v6 of timbre for #67

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.11.1"]
-                 [com.taoensso/timbre "6.1.0"]
+                 [com.taoensso/timbre "6.2.2"]
                  [org.slf4j/slf4j-api "2.0.7"]]
   :profiles {:dev
              {:dependencies [[midje "1.10.9"]]

--- a/src/slf4j_timbre/factory.clj
+++ b/src/slf4j_timbre/factory.clj
@@ -11,14 +11,14 @@
 
 (defn -init
   []
-  (let [default-config (var-get (resolve 'taoensso.timbre/example-config))]
-    (when (and (compare-and-set! bootstrapped? false true) (= timbre/*config* default-config))
-      (let [level (or (System/getProperty "TIMBRE_LEVEL") (System/getenv "TIMBRE_LEVEL") ":info")]
-        (reset! slf4j-timbre.adapter/override-level (keyword (subs level 1))))
-      (add-watch #'timbre/*config* ::on-first-config
-                 (fn [_ _ _ _]
-                   (reset! slf4j-timbre.adapter/override-level nil)
-                   (remove-watch #'timbre/*config* ::on-first-config)))))
+  (when (and (compare-and-set! bootstrapped? false true)
+             (= (dissoc timbre/*config* :_init-config) timbre/default-config))
+    (let [level (or @#'timbre/compile-time-min-level :info)]
+      (reset! slf4j-timbre.adapter/override-level level))
+    (add-watch #'timbre/*config* ::on-first-config
+               (fn [_ _ _ _]
+                 (reset! slf4j-timbre.adapter/override-level nil)
+                 (remove-watch #'timbre/*config* ::on-first-config))))
   [[] (atom {})])
 
 (defn -getLogger


### PR DESCRIPTION
I believe this fixes #67 but I admit I'm not positive on the original intent here using the elision env var TIMBRE_LEVEL? It looks like `timbre/compile-time-min-level` will resolve each of the vars though: 

```clojure
level
           (or
             (enc/read-sys-val "taoensso.timbre.min-level.edn" "TAOENSSO_TIMBRE_MIN_LEVEL_EDN")
             (enc/read-sys-val "TIMBRE_LEVEL")     ; Legacy
             (enc/read-sys-val "TIMBRE_LOG_LEVEL") ; Legacy
             )
```